### PR TITLE
change mentions of <Project Radius> to just <Radius>

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Project Radius Authors.
+   Copyright 2023 Radius Authors.
 
    and others that have contributed code to the public domain.
 


### PR DESCRIPTION
## Description
This change is to replace all mentions of "Project Radius" to just "Radius" as a part of the rebranding effort leading up to public release.

## Issue reference
Fixes: [ADO-6722](https://dev.azure.com/azure-octo/Incubations/_workitems/edit/6722)