### PR TITLE
Remove connection string and add 'tls'

### DIFF
--- a/aws/rediscaches.bicep
+++ b/aws/rediscaches.bicep
@@ -42,8 +42,6 @@ output result object = {
   values: {
     host: memoryDBCluster.properties.ClusterEndpoint.Address
     port: memoryDBCluster.properties.ClusterEndpoint.Port
-  }
-  secrets: {
-    url: 'rediss://${memoryDBCluster.properties.ClusterEndpoint.Address}:${memoryDBCluster.properties.ClusterEndpoint.Port}'
+    tls: true
   }
 }


### PR DESCRIPTION
This PR removes the connection to the URL for the memory db recipe so that the connection URL is constructed at run time by Radius.  
