### PR TITLE
renaming from project-radius to radius-project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Radius!
 
-This project has adopted the [Contributor Covenant Code of Conduct](https://github.com/project-radius/radius/blob/main/CODE-OF-CONDUCT.md).
+This project has adopted the [Contributor Covenant Code of Conduct](https://github.com/radius-project/radius/blob/main/CODE-OF-CONDUCT.md).
 
 Contributions come in many forms: submitting issues, writing code, participating in discussions and community calls.
 
@@ -26,9 +26,9 @@ There are 2 types of issues:
 Before you file an issue, make sure you've checked the following:
 
 1. Is it the right repository?
-    - The Radius project is distributed across multiple repositories. Check the list of [repositories](https://github.com/project-radius) if you aren't sure which repo is the correct one.
+    - The Radius project is distributed across multiple repositories. Check the list of [repositories](https://github.com/radius-project) if you aren't sure which repo is the correct one.
 1. Check for existing issues
-    - Before you create a new issue, please do a search in [open issues](https://github.com/project-radius/recipes/issues) to see if the issue or feature request has already been filed.
+    - Before you create a new issue, please do a search in [open issues](https://github.com/radius-project/recipes/issues) to see if the issue or feature request has already been filed.
     - If you find your issue already exists, make relevant comments and add your [reaction](https://github.com/blog/2119-add-reaction-to-pull-requests-issues-and-comments). Use a reaction:
         - 👍 up-vote
         - 👎 down-vote
@@ -36,9 +36,9 @@ Before you file an issue, make sure you've checked the following:
     - Check it's not an environment issue. For example, if running on Kubernetes, make sure prerequisites are in place.
     - Ensure you have as much data as possible. This usually comes in the form of logs and/or stacktrace. If running on Kubernetes or other environment, look at the logs of the Radius services (UCP, RP, DE). More details on how to get logs can be found [here](https://docs.radapp.dev/reference/troubleshooting-radius/).
 1. For proposals
-    - Many changes to the Radius runtime may require changes to the API. In that case, the best place to discuss the potential feature is the main [Radius repo](https://github.com/project-radius/radius).
-    - Recipes runtime changes can be discussed in the [Radius repo](https://github.com/project-radius/radius).
-    - Community Recipes can be discussed within [this repo](https://github.com/project-radius/recipes/issues).
+    - Many changes to the Radius runtime may require changes to the API. In that case, the best place to discuss the potential feature is the main [Radius repo](https://github.com/radius-project/radius).
+    - Recipes runtime changes can be discussed in the [Radius repo](https://github.com/radius-project/radius).
+    - Community Recipes can be discussed within [this repo](https://github.com/radius-project/recipes/issues).
 
 ## Contributing to Radius Recipes
 

--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ We welcome contributions to this repo! Please see our [contributing guide](/CONT
 
 ## Code of Conduct
 
-Please refer to our [Radius Community Code of Conduct](https://github.com/project-radius/radius/blob/main/CODE_OF_CONDUCT.md)
+Please refer to our [Radius Community Code of Conduct](https://github.com/radius-project/radius/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
As part of OSS effort, we should rename all occurrences of project-radius to radius-project in our repos.