### PR TITLE
enable PRs from fork to work without failure

### DIFF
--- a/.github/workflows/publish-recipes.yaml
+++ b/.github/workflows/publish-recipes.yaml
@@ -17,9 +17,6 @@
 name: Publish Recipes
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/validate-bicep.yaml
+++ b/.github/workflows/validate-bicep.yaml
@@ -37,12 +37,6 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
-    - name: az CLI login
-      run: |
-        az login --service-principal \
-          --username ${{ secrets.AZURE_SP_TESTS_APPID }} \
-          --password ${{ secrets.AZURE_SP_TESTS_PASSWORD }} \
-          --tenant ${{ secrets.AZURE_SP_TESTS_TENANTID }}
     - name: Parse release version and set environment variables
       run: python ./.github/scripts/get_release_version.py
     - name: Download rad-bicep


### PR DESCRIPTION
This PR removes 
- az login step which was not necessary 
- pushes to GHCR since at this point we do not use the pushed images for any valdiation