### PR TITLE
fixed Recipes docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ resource myenv 'Applications.Core/environments' = {
 }
 ```
 
-For more information on using Recipes refer to the [Radius docs](https://docs.radapp.dev/author-apps/recipes).
+For more information on using Recipes refer to the [Radius docs](https://docs.radapp.io/guides/recipes/overview/).
 
 ## Contributing
 


### PR DESCRIPTION
Fixed a broken link to the Recipes docs section, replaced with the Recipes Overview article.