### PR TITLE
Update k3d create command in workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Download k3d
         run: wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
       - name: Create k3d cluster
-        run: k3d cluster create --agents 2 -p "80:80@loadbalancer" --k3s-arg "--disable=traefik@server:0" --registry-create reciperegistry:51351
+        run: k3d cluster create --agents 2 -p "80:80@loadbalancer" --k3s-arg "--disable=traefik@server:*" --k3s-arg "--disable=servicelb@server:*" --registry-create reciperegistry:51351
       - name: Install Dapr
         run: |
           helm repo add dapr https://dapr.github.io/helm-charts/


### PR DESCRIPTION
## Description

This PR updates the workflow command used for creating a k3d cluster by adding a parameter to `k3d cluster create` to disable the default load balancer. The default load balancer was conflicting with the load balancer deployed by Radius. See the issue reference linked below for details.

Note: `traefik@server:0` was changed to `traefik@server:*` to indicate that all instances should be affected, not just the one at index zero.

## Issue reference

Fixes: https://github.com/radius-project/radius/issues/7637