### PR TITLE
Add Dependabot cooldown to all updates entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ci
       include: scope


### PR DESCRIPTION
## Summary

Adds a `cooldown` block (`default-days: 7`) to every active `updates:` entry in `.github/dependabot.yml`. The cooldown delays Dependabot update PRs until 7 days after a dependency release, reducing PR churn from rapid-fire releases while still keeping dependencies current.

This change is scoped to this repository and is part of an org-wide rollout following [radius-project/radius #12141](https://github.com/radius-project/radius/pull/12141) ("Add Dependabot cooldown to all updates entries").

## Changes

- `.github/dependabot.yml`: inserted the following after the `schedule:` block of the `github-actions` updates entry:

  ```yaml
  cooldown:
    default-days: 7
  ```

The file remains valid YAML and schema-valid (Dependabot v2 / schemastore 2.0).

## Type of change

Maintenance / no functional change. This only affects Dependabot scheduling behavior and introduces no runtime or product changes.